### PR TITLE
Feature/create chat room

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,9 @@ dependencies {
     //map struct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+
+    //mongodb
+    implementation 'org.springframework.boot:spring-boot-starter-data-mongodb-reactive'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/controller/ChatController.java
@@ -1,0 +1,43 @@
+package com.daangn.dangunmarket.domain.chat.controller;
+
+import com.daangn.dangunmarket.domain.auth.jwt.CustomUser;
+import com.daangn.dangunmarket.domain.chat.controller.dto.ChatRoomCreateApiRequest;
+import com.daangn.dangunmarket.domain.chat.controller.dto.ChatRoomCreateApiResponse;
+import com.daangn.dangunmarket.domain.chat.controller.mapper.ChatDtoApiMapper;
+import com.daangn.dangunmarket.domain.chat.facade.ChatRoomFacade;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping(
+        value = "/chats",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+@RestController
+public class ChatController {
+
+    private final ChatRoomFacade createChatRoom;
+    private final ChatDtoApiMapper chatDtoApiMapper;
+
+    public ChatController(ChatRoomFacade createChatRoom, ChatDtoApiMapper chatDtoApiMapper) {
+        this.createChatRoom = createChatRoom;
+        this.chatDtoApiMapper = chatDtoApiMapper;
+    }
+
+    @PostMapping(
+            consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<ChatRoomCreateApiResponse> createChatRoom(@RequestBody ChatRoomCreateApiRequest request, Authentication authentication) {
+
+        CustomUser customUser = (CustomUser) authentication.getPrincipal();
+
+        Long chatRoomId = createChatRoom.createChatRoom(customUser.memberId(), chatDtoApiMapper.toChatRoomCreateRequest(request));
+        ChatRoomCreateApiResponse response = chatDtoApiMapper.toChatRoomCreateApiResponse(chatRoomId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/controller/dto/ChatRoomCreateApiRequest.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/controller/dto/ChatRoomCreateApiRequest.java
@@ -1,0 +1,5 @@
+package com.daangn.dangunmarket.domain.chat.controller.dto;
+
+public record ChatRoomCreateApiRequest (
+        Long postId) {
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/controller/dto/ChatRoomCreateApiResponse.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/controller/dto/ChatRoomCreateApiResponse.java
@@ -1,0 +1,5 @@
+package com.daangn.dangunmarket.domain.chat.controller.dto;
+
+public record ChatRoomCreateApiResponse(
+        Long chatRoomId) {
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/controller/mapper/ChatDtoApiMapper.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/controller/mapper/ChatDtoApiMapper.java
@@ -1,0 +1,17 @@
+package com.daangn.dangunmarket.domain.chat.controller.mapper;
+
+import com.daangn.dangunmarket.domain.chat.controller.dto.ChatRoomCreateApiRequest;
+import com.daangn.dangunmarket.domain.chat.controller.dto.ChatRoomCreateApiResponse;
+import com.daangn.dangunmarket.domain.chat.service.dto.ChatRoomCreateRequest;
+import org.mapstruct.InjectionStrategy;
+import org.mapstruct.Mapper;
+
+@Mapper(
+        componentModel = "spring",
+        injectionStrategy = InjectionStrategy.CONSTRUCTOR
+)
+public interface ChatDtoApiMapper {
+
+    ChatRoomCreateRequest toChatRoomCreateRequest(ChatRoomCreateApiRequest chatRoomCreateApiRequest);
+    ChatRoomCreateApiResponse toChatRoomCreateApiResponse(Long chatRoomId);
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/exception/RoomNotCreateException.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/exception/RoomNotCreateException.java
@@ -1,0 +1,14 @@
+package com.daangn.dangunmarket.domain.chat.exception;
+
+import com.daangn.dangunmarket.global.response.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class RoomNotCreateException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public RoomNotCreateException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/facade/ChatRoomFacade.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/facade/ChatRoomFacade.java
@@ -1,0 +1,36 @@
+package com.daangn.dangunmarket.domain.chat.facade;
+
+import com.daangn.dangunmarket.domain.chat.exception.RoomNotCreateException;
+import com.daangn.dangunmarket.domain.chat.service.ChatRoomInfoService;
+import com.daangn.dangunmarket.domain.chat.service.dto.ChatRoomCreateRequest;
+import com.daangn.dangunmarket.domain.chat.service.ChatRoomService;
+import com.daangn.dangunmarket.domain.post.service.PostService;
+import com.daangn.dangunmarket.domain.post.service.dto.PostFindResponse;
+import org.springframework.stereotype.Service;
+
+import static com.daangn.dangunmarket.global.response.ErrorCode.NOT_CREATE_CHAT_ROOM;
+
+@Service
+public class ChatRoomFacade {
+
+    private final PostService postService;
+    private final ChatRoomService chatRoomService;
+    private final ChatRoomInfoService chatRoomInfoService;
+
+    public ChatRoomFacade(PostService postService, ChatRoomService chatRoomService, ChatRoomInfoService chatRoomInfoService) {
+        this.postService = postService;
+        this.chatRoomService = chatRoomService;
+        this.chatRoomInfoService = chatRoomInfoService;
+    }
+
+    public Long createChatRoom(Long memberId, ChatRoomCreateRequest request){
+
+        if(chatRoomInfoService.isExistedRoom(request.postId(),memberId)) {
+            throw new RoomNotCreateException(NOT_CREATE_CHAT_ROOM);
+        }
+
+        PostFindResponse postFindResponse = postService.findById(request.postId());
+        return chatRoomService.createChatRoom(memberId,postFindResponse.memberId(),request);
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatMessage.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatMessage.java
@@ -1,38 +1,53 @@
 package com.daangn.dangunmarket.domain.chat.model;
 
-import com.daangn.dangunmarket.domain.member.model.Member;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+import org.springframework.data.mongodb.core.mapping.FieldType;
 
-@Entity
-@Table(name = "chat_messages")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+import java.time.LocalDateTime;
+
+@Document(collection = "chat_messages")
+@Getter
+@NoArgsConstructor
 public class ChatMessage {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Field(value = "_id", targetType = FieldType.OBJECT_ID)
+    private String id;
 
-    @Column(nullable = false)
-    private String content;
+    @Field("chat_room_id")
+    private Long chatRoomId;
 
-    @Column(nullable = false)
-    private boolean readOrNot;
+    @Field("sender_name")
+    private String senderName;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "chat_room_infos_id", referencedColumnName = "id", nullable = false)
-    private ChatRoomInfo chatRoomInfo;
+    @Field("member_id")
+    private Long memberId;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "members_id", referencedColumnName = "id", nullable = false)
-    private Member member;
+    @Field("message")
+    private String message;
 
-    public ChatMessage(String content, boolean readOrNot, ChatRoomInfo chatRoomInfo, Member member) {
-        this.content = content;
+    @Field("img_url")
+    private String imgUrl;
+
+    @Field("read_or_not")
+    private Integer readOrNot;
+
+    @Field("created_at")
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    public ChatMessage(Long chatRoomId, String senderName, Long memberId, String message, String imgUrl, Integer readOrNot) {
+        this.chatRoomId = chatRoomId;
+        this.senderName = senderName;
+        this.memberId = memberId;
+        this.message = message;
+        this.imgUrl = imgUrl;
         this.readOrNot = readOrNot;
-        this.chatRoomInfo = chatRoomInfo;
-        this.member = member;
     }
 
 }

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatRoom.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatRoom.java
@@ -2,11 +2,13 @@ package com.daangn.dangunmarket.domain.chat.model;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "chat_rooms")
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@NoArgsConstructor
 public class ChatRoom {
 
     @Id

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatRoomInfo.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/model/ChatRoomInfo.java
@@ -1,13 +1,15 @@
 package com.daangn.dangunmarket.domain.chat.model;
 
-import com.daangn.dangunmarket.domain.member.model.Member;
-import com.daangn.dangunmarket.domain.post.model.Post;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.util.Assert;
 
 @Entity
 @Table(name = "chat_room_infos")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoomInfo {
 
@@ -17,23 +19,26 @@ public class ChatRoomInfo {
 
     private boolean isWriter;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "products_id", referencedColumnName = "id", nullable = false)
-    private Post post;
+    @Column(nullable = false,name = "posts_id")
+    private Long postId;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "chatrooms_id", referencedColumnName = "id", nullable = false)
-    private ChatRoom chatroom;
+    private ChatRoom chatRoom;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "members_id", referencedColumnName = "id", nullable = false)
-    private Member member;
+    @Column(nullable = false, name = "members_id")
+    private Long memberId;
 
-    public ChatRoomInfo(boolean isWriter, Post post, ChatRoom chatroom, Member member) {
+    @Builder
+    public ChatRoomInfo(boolean isWriter, Long postId, ChatRoom chatRoom, Long memberId) {
+        Assert.notNull(postId, "postId는 null값이 들어올 수 없습니다.");
+        Assert.notNull(chatRoom, "chatRoom는 null값이 들어올 수 없습니다.");
+        Assert.notNull(memberId, "memberId는 null값이 들어올 수 없습니다.");
+
         this.isWriter = isWriter;
-        this.post = post;
-        this.chatroom = chatroom;
-        this.member = member;
+        this.postId = postId;
+        this.chatRoom = chatRoom;
+        this.memberId = memberId;
     }
 
 }

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomJpaRepository.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomJpaRepository.java
@@ -1,0 +1,7 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroom;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatRoomJpaRepository extends JpaRepository<ChatRoom, Long> {
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomRepository.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomRepository.java
@@ -1,0 +1,12 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroom;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+
+import java.util.Optional;
+
+public interface ChatRoomRepository {
+
+    ChatRoom save(ChatRoom chatRoom);
+
+    Optional<ChatRoom> findById(Long chatRoomId);
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomRepositoryImpl.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroom/ChatRoomRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroom;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class ChatRoomRepositoryImpl implements ChatRoomRepository{
+
+    private final ChatRoomJpaRepository chatRoomJpaRepository;
+
+    public ChatRoomRepositoryImpl(ChatRoomJpaRepository chatRoomJpaRepository) {
+        this.chatRoomJpaRepository = chatRoomJpaRepository;
+    }
+
+    @Override
+    public ChatRoom save(ChatRoom chatRoom) {
+        return chatRoomJpaRepository.save(chatRoom);
+    }
+
+    @Override
+    public Optional<ChatRoom> findById(Long chatRoomId) {
+        return chatRoomJpaRepository.findById(chatRoomId);
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoJpaRepository.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoJpaRepository.java
@@ -1,0 +1,14 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroominfo;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface ChatRoomInfoJpaRepository extends JpaRepository<ChatRoomInfo, Long> {
+
+    @Query("SELECT c FROM ChatRoomInfo c WHERE c.memberId=:memberId AND c.postId=:postId ")
+    Optional<ChatRoomInfo> findChatRoomInfoByPostIdAndMemberId(@Param("postId") Long postId, @Param("memberId") Long memberId);
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoRepository.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoRepository.java
@@ -1,0 +1,13 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroominfo;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+
+import java.util.Optional;
+
+public interface ChatRoomInfoRepository {
+
+  Optional<ChatRoomInfo> findChatRoomInfoByPostIdAndMemberId(Long postId, Long memberId);
+
+  ChatRoomInfo save(ChatRoomInfo chatRoomInfo);
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoRepositoryImpl.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/repository/chatroominfo/ChatRoomInfoRepositoryImpl.java
@@ -1,0 +1,27 @@
+package com.daangn.dangunmarket.domain.chat.repository.chatroominfo;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public class ChatRoomInfoRepositoryImpl implements ChatRoomInfoRepository{
+
+    private final ChatRoomInfoJpaRepository chatRoomInfoJpaRepository;
+
+    public ChatRoomInfoRepositoryImpl(ChatRoomInfoJpaRepository chatRoomInfoJpaRepository) {
+        this.chatRoomInfoJpaRepository = chatRoomInfoJpaRepository;
+    }
+
+    @Override
+    public Optional<ChatRoomInfo> findChatRoomInfoByPostIdAndMemberId(Long postId, Long memberId) {
+        return chatRoomInfoJpaRepository.findChatRoomInfoByPostIdAndMemberId(postId,memberId);
+    }
+
+    @Override
+    public ChatRoomInfo save(ChatRoomInfo chatRoomInfo) {
+        return chatRoomInfoJpaRepository.save(chatRoomInfo);
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomInfoService.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomInfoService.java
@@ -1,0 +1,23 @@
+package com.daangn.dangunmarket.domain.chat.service;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import com.daangn.dangunmarket.domain.chat.repository.chatroominfo.ChatRoomInfoRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class ChatRoomInfoService {
+
+    private final ChatRoomInfoRepository chatRoomInfoRepository;
+
+    public ChatRoomInfoService(ChatRoomInfoRepository chatRoomInfoRepository) {
+        this.chatRoomInfoRepository = chatRoomInfoRepository;
+    }
+
+    public boolean isExistedRoom(Long postId, Long memberId) {
+       Optional<ChatRoomInfo> chatRoomInfo = chatRoomInfoRepository.findChatRoomInfoByPostIdAndMemberId(postId,memberId);
+       return chatRoomInfo.isPresent();
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomService.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomService.java
@@ -1,0 +1,37 @@
+package com.daangn.dangunmarket.domain.chat.service;
+
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import com.daangn.dangunmarket.domain.chat.repository.chatroom.ChatRoomRepository;
+import com.daangn.dangunmarket.domain.chat.repository.chatroominfo.ChatRoomInfoRepository;
+import com.daangn.dangunmarket.domain.chat.service.dto.ChatRoomCreateRequest;
+import com.daangn.dangunmarket.domain.post.repository.post.PostRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChatRoomService {
+
+    private final ChatRoomInfoRepository chatRoomInfoRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final PostRepository postRepository;
+
+    public ChatRoomService(ChatRoomInfoRepository chatRoomInfoRepository, ChatRoomRepository chatRoomRepository, PostRepository postRepository) {
+        this.chatRoomInfoRepository = chatRoomInfoRepository;
+        this.chatRoomRepository = chatRoomRepository;
+        this.postRepository = postRepository;
+    }
+
+    public Long createChatRoom(Long memberId, Long writerId, ChatRoomCreateRequest request) {
+
+        ChatRoom chatRoom = new ChatRoom();
+        ChatRoom savedChatRoom = chatRoomRepository.save(chatRoom);
+
+        ChatRoomInfo sellerChatRoomInfo = new ChatRoomInfo(true, request.postId(), savedChatRoom, writerId);
+        chatRoomInfoRepository.save(sellerChatRoomInfo);
+        ChatRoomInfo buyerChatRoomInfo = new ChatRoomInfo(false, request.postId(), savedChatRoom, memberId);
+        chatRoomInfoRepository.save(buyerChatRoomInfo);
+
+        return chatRoom.getId();
+    }
+
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/service/dto/ChatRoomCreateRequest.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/service/dto/ChatRoomCreateRequest.java
@@ -1,0 +1,5 @@
+package com.daangn.dangunmarket.domain.chat.service.dto;
+
+public record ChatRoomCreateRequest(
+        Long postId) {
+}

--- a/src/main/java/com/daangn/dangunmarket/domain/chat/service/dto/ChatRoomCreateResponse.java
+++ b/src/main/java/com/daangn/dangunmarket/domain/chat/service/dto/ChatRoomCreateResponse.java
@@ -1,0 +1,5 @@
+package com.daangn.dangunmarket.domain.chat.service.dto;
+
+public record ChatRoomCreateResponse (Long chatRoomId){
+
+}

--- a/src/main/java/com/daangn/dangunmarket/global/response/ErrorCode.java
+++ b/src/main/java/com/daangn/dangunmarket/global/response/ErrorCode.java
@@ -4,7 +4,6 @@ import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
-
     //global
     INTERNAL_SERVER_ERROR("G001", "Internal Server Error"),
 
@@ -35,7 +34,10 @@ public enum ErrorCode {
     //login
     EXPIRED_TOKEN("L001", "토큰이 만료되었습니다."),
     UNAUTHORIZED_TOKEN("L002", "인증되지 않은 토큰입니다."),
-    OAUTH_CLIENT_SERVER_ERROR("L003", "oauth 클라이언트 서버 에러입니다.");
+    OAUTH_CLIENT_SERVER_ERROR("L003", "oauth 클라이언트 서버 에러입니다."),
+
+    //chat
+    NOT_CREATE_CHAT_ROOM("C001","이미 존재하는 방입니다.");
 
     private final String code;
     private final String message;

--- a/src/test/java/com/daangn/dangunmarket/domain/DataInitializerFactory.java
+++ b/src/test/java/com/daangn/dangunmarket/domain/DataInitializerFactory.java
@@ -1,16 +1,23 @@
 package com.daangn.dangunmarket.domain;
 
 import com.daangn.dangunmarket.domain.area.model.Area;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
 import com.daangn.dangunmarket.domain.member.model.Member;
 import com.daangn.dangunmarket.domain.member.model.NickName;
 import com.daangn.dangunmarket.domain.post.facade.dto.PostCreateRequestParam;
 import com.daangn.dangunmarket.domain.post.facade.dto.PostUpdateRequestParam;
 import com.daangn.dangunmarket.domain.post.model.Category;
+import com.daangn.dangunmarket.domain.post.model.Post;
+import com.daangn.dangunmarket.domain.post.model.TradeStatus;
+import com.daangn.dangunmarket.domain.post.model.vo.Price;
+import com.daangn.dangunmarket.domain.post.model.vo.Title;
 import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.MultiPolygon;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.core.parameters.P;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
@@ -65,6 +72,17 @@ public final class DataInitializerFactory {
                 .build();
     }
 
+    public static Member member2() {
+        return Member.builder()
+                .roleType(USER)
+                .memberProvider(GOOGLE)
+                .socialId("member2 socialId")
+                .nickName(new NickName("byeol"))
+                .reviewScore(26)
+                .build();
+    }
+
+
     public static Category category() {
         return new Category("전자기기", null, 1L, new ArrayList<>());
     }
@@ -83,6 +101,18 @@ public final class DataInitializerFactory {
         List<MultipartFile> updateMockMultipartFiles = List.of(new MockMultipartFile("테스트1", (byte[]) null), new MockMultipartFile("테스트2", (byte[]) null));
         List<String> urls = new ArrayList<>();
         return new PostUpdateRequestParam(postId, 37.5297, 126.8876, "데브코스 공원 벤치", updateMockMultipartFiles, urls, categoryId, "의자 팔아요", "아기가 쓰던 의자입니다.", 100000L, true);
+    }
+
+    public static ChatRoomInfo sellerChatRoomInfo(Long postId, Long writerId, ChatRoom chatRoom) {
+        return new ChatRoomInfo(true, postId, chatRoom, writerId);
+    }
+
+    public static ChatRoomInfo buyerChatRoomInfo(Long postId, Long buyerId, ChatRoom chatRoom) {
+        return new ChatRoomInfo(false, postId, chatRoom, buyerId);
+    }
+
+    public static Post post(Long memberId, Category category) {
+        return new Post(memberId, 2L, null, new ArrayList<>(), category, TradeStatus.IN_PROGRESS, new Title("달님이 젤리 가게"), "사용감 있습니다.", new Price(10000), true, LocalDateTime.now(), 0);
     }
 
 }

--- a/src/test/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomInfoServiceTest.java
+++ b/src/test/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomInfoServiceTest.java
@@ -1,0 +1,86 @@
+package com.daangn.dangunmarket.domain.chat.service;
+
+import com.daangn.dangunmarket.domain.DataInitializerFactory;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import com.daangn.dangunmarket.domain.chat.repository.chatroom.ChatRoomRepository;
+import com.daangn.dangunmarket.domain.chat.repository.chatroominfo.ChatRoomInfoRepository;
+import com.daangn.dangunmarket.domain.chat.service.dto.ChatRoomCreateRequest;
+import com.daangn.dangunmarket.domain.post.model.Category;
+import com.daangn.dangunmarket.domain.post.model.Post;
+import com.daangn.dangunmarket.domain.post.repository.category.CategoryRepository;
+import com.daangn.dangunmarket.domain.post.repository.post.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ChatRoomInfoServiceTest {
+
+    @Autowired
+    ChatRoomInfoService chatRoomInfoService;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    ChatRoomInfoRepository chatRoomInfoRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    Long existedSellerId;
+    Long existedPostId;
+    Long existedBuyerId;
+
+    ChatRoom savedChatRoom;
+
+    @BeforeEach
+    void setUp() {
+        dateSetUp();
+    }
+
+    @Test
+    @DisplayName("방 정보가 존재하면 true, 존재하지 않으면 false를 반환한다.")
+    void isExistedRoom_existedIdOrNot_returnTrueOrFalse() {
+        //when_then
+        assertThat(chatRoomInfoService.isExistedRoom(existedPostId,existedBuyerId)).isEqualTo(true);
+        assertThat(chatRoomInfoService.isExistedRoom(existedPostId,existedSellerId)).isEqualTo(true);
+        assertThat(chatRoomInfoService.isExistedRoom(existedPostId+1,existedBuyerId)).isEqualTo(false);
+    }
+
+    void dateSetUp() {
+
+        ChatRoom chatRoom = new ChatRoom();
+        savedChatRoom = chatRoomRepository.save(chatRoom);
+
+        existedBuyerId = 1L;
+        existedSellerId = 2L;
+
+        Category category = DataInitializerFactory.category();
+        Category savedeCategory = categoryRepository.save(category);
+
+        Post post = DataInitializerFactory.post(existedSellerId, savedeCategory);
+        Post savedPost = postRepository.save(post);
+
+        existedPostId = savedPost.getId();
+
+        ChatRoomInfo buyderChatRoomInfo = DataInitializerFactory.buyerChatRoomInfo(existedPostId, existedBuyerId, savedChatRoom);
+        ChatRoomInfo sellerChatRoomInfo = DataInitializerFactory.sellerChatRoomInfo(existedPostId, existedSellerId, savedChatRoom);
+
+        chatRoomInfoRepository.save(buyderChatRoomInfo);
+        chatRoomInfoRepository.save(sellerChatRoomInfo);
+    }
+
+}

--- a/src/test/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomServiceTest.java
+++ b/src/test/java/com/daangn/dangunmarket/domain/chat/service/ChatRoomServiceTest.java
@@ -1,0 +1,93 @@
+package com.daangn.dangunmarket.domain.chat.service;
+
+import com.daangn.dangunmarket.domain.DataInitializerFactory;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoom;
+import com.daangn.dangunmarket.domain.chat.model.ChatRoomInfo;
+import com.daangn.dangunmarket.domain.chat.repository.chatroom.ChatRoomRepository;
+import com.daangn.dangunmarket.domain.chat.repository.chatroominfo.ChatRoomInfoRepository;
+import com.daangn.dangunmarket.domain.chat.service.dto.ChatRoomCreateRequest;
+import com.daangn.dangunmarket.domain.post.model.Category;
+import com.daangn.dangunmarket.domain.post.model.Post;
+import com.daangn.dangunmarket.domain.post.repository.category.CategoryRepository;
+import com.daangn.dangunmarket.domain.post.repository.post.PostRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+@ActiveProfiles("test")
+class ChatRoomServiceTest {
+
+    @Autowired
+    ChatRoomService chatRoomService;
+
+    @Autowired
+    ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    ChatRoomInfoRepository chatRoomInfoRepository;
+
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    Long existedSellerId;
+    Long existedPostId;
+    Long existedBuyerId;
+
+    ChatRoom savedChatRoom;
+
+    @BeforeEach
+    void setUp() {
+        dateSetUp();
+    }
+
+    @Test
+    @DisplayName("채팅방을 생성하고 채팅방 아이디로 다시 찾았을 때 존재하는 채팅방을 반환하는지 확인한다.")
+    void createChatRoom_Optional_returnIsPresent() {
+        //given
+        Long newBuyerId = existedBuyerId + 1;
+        ChatRoomCreateRequest chatRoomCreateRequest = new ChatRoomCreateRequest(existedPostId);
+
+        //when
+        Long chatRoomId = chatRoomService.createChatRoom(newBuyerId, existedSellerId ,chatRoomCreateRequest);
+        Optional<ChatRoom> chatRoom = chatRoomRepository.findById(chatRoomId);
+
+        //then
+        assertThat(chatRoom.isPresent()).isEqualTo(true);
+    }
+
+    void dateSetUp() {
+        ChatRoom chatRoom = new ChatRoom();
+        savedChatRoom = chatRoomRepository.save(chatRoom);
+
+        existedBuyerId = 1L;
+        existedSellerId = 2L;
+
+        Category category = DataInitializerFactory.category();
+        Category savedeCategory = categoryRepository.save(category);
+
+        Post post = DataInitializerFactory.post(existedSellerId, savedeCategory);
+        Post savedPost = postRepository.save(post);
+
+        existedPostId = savedPost.getId();
+
+        ChatRoomInfo buyderChatRoomInfo = DataInitializerFactory.buyerChatRoomInfo(existedPostId, existedBuyerId, savedChatRoom);
+        ChatRoomInfo sellerChatRoomInfo = DataInitializerFactory.sellerChatRoomInfo(existedPostId, existedSellerId, savedChatRoom);
+
+        chatRoomInfoRepository.save(buyderChatRoomInfo);
+        chatRoomInfoRepository.save(sellerChatRoomInfo);
+
+    }
+
+}


### PR DESCRIPTION
## 📌 과제 설명 
- `POST`, `/chats`
- 요청 :  `{ "postId": 11}`
- 서비스 로직
   - 존재하는 게시글인가 확인하는 과정
   - 이미 존재하는 채팅룸인가 확인 과정
   - 모두 통과하면
      - ChatRoom을 생성하고 
      - 판매자의 ChatRoomInfo와 구매자의 ChatRoomInfo를 저장
- 응답 : `{"chatRoomId": 1}`

## 더 살펴볼 것
응답 값의 경우 `채팅방 입장 구현`할 때 어떤 정보가 필요한지 살펴본 후 부가적인 정보를 추가하도록 하겠습니다.

